### PR TITLE
generic_no_telephony: Allow devices to override AOSP audio_effects

### DIFF
--- a/target/product/generic_no_telephony.mk
+++ b/target/product/generic_no_telephony.mk
@@ -46,7 +46,7 @@ PRODUCT_PACKAGES += \
     vibrator.default \
     power.default
 
-PRODUCT_COPY_FILES := \
+PRODUCT_COPY_FILES ?= \
         frameworks/av/media/libeffects/data/audio_effects.conf:system/etc/audio_effects.conf
 
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
PRODUCT_COPY_FILES device/lge/bullhead/audio_effects.conf:system/etc/audio_effects.conf ignored.