### PR TITLE
build: only warn on LOCAL_CLANG set to false

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -380,7 +380,7 @@ endif
 # in the exception project list.
 ifeq ($(my_clang),false)
     ifeq ($(call find_in_local_clang_exception_projects,$(LOCAL_MODULE_MAKEFILE))$(LOCAL_IS_AUX_MODULE),)
-        $(error $(LOCAL_MODULE_MAKEFILE): $(LOCAL_MODULE): LOCAL_CLANG is set to false)
+        $(warning $(LOCAL_MODULE_MAKEFILE): $(LOCAL_MODULE): LOCAL_CLANG is set to false)
     endif
 endif
 


### PR DESCRIPTION
* Some blobs require this

Change-Id: I4b73f595f5c795d487688fdacc47bfcaebdff19a