### PR TITLE
Don't enable ANDROID_BINDER_IPC_32BIT for mixed userspace/kernel

### DIFF
--- a/core/tasks/kernel.mk
+++ b/core/tasks/kernel.mk
@@ -121,9 +121,6 @@ endif
 ifeq ($(KERNEL_ARCH),arm64)
   # Avoid "unsupported RELA relocation: 311" errors (R_AARCH64_ADR_GOT_PAGE)
   MAKE_FLAGS += CFLAGS_MODULE="-fno-pic"
-  ifeq ($(TARGET_ARCH),arm)
-    KERNEL_CONFIG_OVERRIDE := CONFIG_ANDROID_BINDER_IPC_32BIT=y
-  endif
 endif
 
 ifneq ($(TARGET_KERNEL_ADDITIONAL_CONFIG),)


### PR DESCRIPTION
TARGET_USES_64_BIT_BINDER should be used for the userspace binder now.

Change-Id: I5cede00e7667969e394d06169dff54659900d90f